### PR TITLE
Fix build on Windows, synchronize .gitignore and README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,8 +88,6 @@ typings/
 # public
 
 rsbuild-dist
-rspack-dist
-webpack-dist
 # Serverless directories
 .serverless/
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm-run-all build:* --sequential --print-name",
     "build:rspack": "cross-env RSPACK=1 pnpm rspack -c ./rspack.config.mjs",
-    "build:rsbuild": "rsbuild build --env-mode development",
+    "build:rsbuild": "rsbuild build",
     "build:webpack": "cross-env WEBPACK=1 pnpm webpack -c ./rspack.config.mjs",
     "dev:rspack": "cross-env RSPACK=1 rspack dev -c ./rspack.config.mjs",
     "dev:rsbuild": "rsbuild dev",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "index.js",
   "scripts": {
     "build": "npm-run-all build:* --sequential --print-name",
-    "build:rspack": "RSPACK=1 pnpm rspack -c ./rspack.config.mjs",
-    "build:rsbuild": "rsbuild build",
-    "build:webpack": "WEBPACK=1 pnpm webpack -c ./rspack.config.mjs",
-    "dev:rspack": "RSPACK=1 rspack dev -c ./rspack.config.mjs",
+    "build:rspack": "cross-env RSPACK=1 pnpm rspack -c ./rspack.config.mjs",
+    "build:rsbuild": "rsbuild build --env-mode development",
+    "build:webpack": "cross-env WEBPACK=1 pnpm webpack -c ./rspack.config.mjs",
+    "dev:rspack": "cross-env RSPACK=1 rspack dev -c ./rspack.config.mjs",
     "dev:rsbuild": "rsbuild dev",
-    "dev:webpack": "WEBPACK=1 webpack serve -c ./rspack.config.mjs",
+    "dev:webpack": "cross-env WEBPACK=1 webpack serve -c ./rspack.config.mjs",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@rsbuild/core": "^1.0.1",
+    "cross-env": "^7.0.3",
     "npm-run-all2": "^6.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       '@rspack/cli':
         specifier: ^1.0.0
-        version: 1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
+        version: 1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.92.1)
       '@rspack/core':
         specifier: ^1.0.0
         version: 1.0.0(@swc/helpers@0.5.12)
       html-webpack-plugin:
         specifier: ^5.6.0
-        version: 5.6.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(webpack@5.92.1(webpack-cli@5.1.4))
+        version: 5.6.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(webpack@5.92.1)
       webpack:
         specifier: ^5.91.0
         version: 5.92.1(webpack-cli@5.1.4)
@@ -27,6 +27,9 @@ importers:
       '@rsbuild/core':
         specifier: ^1.0.1
         version: 1.0.1
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       npm-run-all2:
         specifier: ^6.2.0
         version: 6.2.0
@@ -604,6 +607,11 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -1915,11 +1923,11 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 1.0.3
       '@rspack/binding-win32-x64-msvc': 1.0.3
 
-  '@rspack/cli@1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))':
+  '@rspack/cli@1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.92.1)':
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
-      '@rspack/dev-server': 1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
+      '@rspack/dev-server': 1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.92.1)
       colorette: 2.0.19
       exit-hook: 3.2.0
       interpret: 3.1.1
@@ -1954,7 +1962,7 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.12
 
-  '@rspack/dev-server@1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))':
+  '@rspack/dev-server@1.0.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.92.1)':
     dependencies:
       '@rspack/core': 1.0.0(@swc/helpers@0.5.12)
       chokidar: 3.6.0
@@ -1962,8 +1970,8 @@ snapshots:
       express: 4.19.2
       http-proxy-middleware: 2.0.6(@types/express@4.17.21)
       mime-types: 2.1.35
-      webpack-dev-middleware: 7.4.2(webpack@5.92.1(webpack-cli@5.1.4))
-      webpack-dev-server: 5.0.4(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.2(webpack@5.92.1)
+      webpack-dev-server: 5.0.4(webpack-cli@5.1.4)(webpack@5.92.1)
       ws: 8.17.1
     transitivePeerDependencies:
       - '@types/express'
@@ -2149,17 +2157,17 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.92.1)':
     dependencies:
       webpack: 5.92.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.92.1)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.92.1)':
     dependencies:
       webpack: 5.92.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.92.1)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.92.1)':
     dependencies:
       webpack: 5.92.1(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.92.1)
@@ -2387,6 +2395,10 @@ snapshots:
   core-js@3.38.1: {}
 
   core-util-is@1.0.3: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.3
 
   cross-spawn@7.0.3:
     dependencies:
@@ -2697,7 +2709,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.31.1
 
-  html-webpack-plugin@5.6.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(webpack@5.92.1(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.0(@rspack/core@1.0.0(@swc/helpers@0.5.12))(webpack@5.92.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -3315,7 +3327,7 @@ snapshots:
 
   tapable@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(webpack@5.92.1(webpack-cli@5.1.4)):
+  terser-webpack-plugin@5.3.10(webpack@5.92.1):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
@@ -3407,9 +3419,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.92.1):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4))
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.92.1)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.92.1)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.92.1)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.3
@@ -3421,7 +3433,7 @@ snapshots:
       webpack: 5.92.1(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
-  webpack-dev-middleware@7.4.2(webpack@5.92.1(webpack-cli@5.1.4)):
+  webpack-dev-middleware@7.4.2(webpack@5.92.1):
     dependencies:
       colorette: 2.0.20
       memfs: 4.11.1
@@ -3432,7 +3444,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.92.1(webpack-cli@5.1.4)
 
-  webpack-dev-server@5.0.4(webpack-cli@5.1.4(webpack@5.92.1))(webpack@5.92.1(webpack-cli@5.1.4)):
+  webpack-dev-server@5.0.4(webpack-cli@5.1.4)(webpack@5.92.1):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -3462,7 +3474,7 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 7.4.2(webpack@5.92.1(webpack-cli@5.1.4))
+      webpack-dev-middleware: 7.4.2(webpack@5.92.1)
       ws: 8.17.1
     optionalDependencies:
       webpack: 5.92.1(webpack-cli@5.1.4)
@@ -3504,7 +3516,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(webpack@5.92.1(webpack-cli@5.1.4))
+      terser-webpack-plugin: 5.3.10(webpack@5.92.1)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     optionalDependencies:


### PR DESCRIPTION
#### Cross-platform compatibility

Makes `pnpm run build` work on both macOS and Windows platforms. While creating the reproduce repo for https://github.com/web-infra-dev/rspack/issues/8170, I noticed that `pnpm run build` worked on macOS but failed on Windows.

On Windows, the error messages from `pnpm run build` initially were

```
Unknown arguments: =1, pnpm, rspack
 ELIFECYCLE  Command failed with exit code 1.
ERROR: "build:rspack" exited with 1.
 ELIFECYCLE  Command failed with exit code 1.
```

Those errors were fixed by adding `cross-env`. After that, the `build:rsbuild` step still failed on Windows with the following error message (fixed with the `--env-mode development`):

```
  Rsbuild v1.0.1
  
error   Failed to build.
error   'local' cannot be used as a value for env mode, because ".env.local" represents a temporary local file. Please use another value.
```

#### .gitignore and README.md synchronization

Remove rspack-dist and webpack-dist from .gitignore to be in sync with README.md ("`./webpack-dist` and `./rspack-dist` are purposely not added to `.gitignore`.")