### PR TITLE
add alias resolve demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,7 @@ typings/
 # https://nextjs.org/blog/next-9-1#public-directory-support
 # public
 
-rsbuild-dist
+*-dist
 # Serverless directories
 .serverless/
 

--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -1,4 +1,29 @@
+import path from 'path';
 import { defineConfig } from "@rsbuild/core";
+
+const alias = {
+  a: path.resolve(__dirname, 'src', 'a.js'),
+  b: 'c',
+  c: path.resolve(__dirname, 'src', 'c.js')
+};
+
+class ResolverPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      ResolverPlugin.name,
+      (compilation, { normalModuleFactory }) => {
+        normalModuleFactory.hooks.beforeResolve.tap(
+          ResolverPlugin.name,
+          (resolveData) => {
+            if (resolveData.request === 'b') {
+              return;
+            }
+          }
+        );
+      }
+    );
+  }
+}
 
 export default defineConfig({
   output: {
@@ -6,4 +31,10 @@ export default defineConfig({
       root: "./rsbuild-dist",
     },
   },
+  resolve: {alias},
+  tools: {
+    rspack: {
+      plugins: [new ResolverPlugin()]
+    }
+  }
 });

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -9,6 +9,54 @@ if (!isRunningRspack && !isRunningWebpack) {
   throw new Error("Unknown bundler");
 }
 
+const alias = {
+  a: path.resolve(__dirname, 'src', 'a.js'),
+  b: 'c',
+  c: path.resolve(__dirname, 'src', 'c.js')
+};
+
+class ResolverPlugin {
+  apply(compiler) {
+    compiler.hooks.compilation.tap(
+      ResolverPlugin.name,
+      (compilation, { normalModuleFactory }) => {
+        normalModuleFactory.hooks.beforeResolve.tap(
+          ResolverPlugin.name,
+          (resolveData) => {
+            const { request } = resolveData;
+
+            if (request === 'a' || request === 'b' || request === 'c') {
+              console.log("before request", request);
+            }
+          }
+        );
+
+        normalModuleFactory.hooks.resolve.tap(
+          ResolverPlugin.name,
+          (resolveData) => {
+            const { request } = resolveData;
+
+            if (request === 'a' || request === 'b' || request === 'c') {
+              console.log("request", request);
+            }
+          }
+        );
+
+        normalModuleFactory.hooks.afterResolve.tap(
+          ResolverPlugin.name,
+          (resolveData) => {
+            const { request } = resolveData;
+
+            if (request === 'a' || request === 'b' || request === 'c') {
+              console.log("after request", request);
+            }
+          }
+        );
+      }
+    );
+  }
+}
+
 /**
  * @type {import('webpack').Configuration | import('@rspack/cli').Configuration}
  */
@@ -18,7 +66,8 @@ const config = {
   entry: {
     main: "./src/index",
   },
-  plugins: [new HtmlWebpackPlugin()],
+  resolve: {alias},
+  plugins: [new HtmlWebpackPlugin(), new ResolverPlugin()],
   output: {
     clean: true,
     path: isRunningWebpack

--- a/src/a.js
+++ b/src/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/src/b.js
+++ b/src/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/src/c.js
+++ b/src/c.js
@@ -1,0 +1,1 @@
+export default 'c';

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+import a from 'a';
+import b from 'b';
+
+console.log('a', a);
+console.log('b', b);
+
 import('./render').then(exports => {
     exports.render()
 })


### PR DESCRIPTION
Confusing demo of how we would like to resolve our alias config.  Our issue is that we are aliasing to a BPM package that has not been fully resolved using complete resolve. You can see from this example if you run `pnpm run dev:rspack` or `pnpm run build` that the `b` request get's resolved to `c.js` because it is a fully resolved path in the `alias` but if you look at the logging in the `ResolverPlugin` hooks there is at no point a request to `c`. Unfortunately, this is what we ideally would want if we want to make something like `quick-fetch` resolve to `quartz/quick-fetch` via alias otherwise we don't have an opportunity to hijack the request and use complete resolve to compute it's full path on disk. So what actually is happening in rspack is:

1. alias configuration is defined on the compiler via the config object or custom plugin that mutates `compiler.optinos.resolve.alias`
2. a request comes into the resolver plugin `beforeResolve` hook
3. that request for something like `quick-fetch` will us complete resolve to resolve to the `quick-fetch` on disk not the aliased `quartz/quick-fetch`
4. because we change this request to a full path on disk in the `beforeResolve` hook this no longer matches the `quick-fetch` alias

Therefore, it is unclear at what point the alias configuration is being utilized internally by rspack for resolution and I'm not sure if we can hook into it and supply the full path to the alias? 